### PR TITLE
Rust and svmkit repo support

### DIFF
--- a/Dockerfile.packages
+++ b/Dockerfile.packages
@@ -1,0 +1,162 @@
+# syntax=docker/dockerfile:1.4
+
+FROM buildkite/agent:3-ubuntu
+
+# Use BuildKit's automatic TARGETPLATFORM support
+ARG TARGETPLATFORM
+ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
+
+ARG NODE_VERSION=20
+ARG GO_VERSION=1.24.6
+ARG RUST_VERSION=1.86.0
+ARG NVM_VERSION=0.40.3
+ARG PULUMICTL_VERSION=0.0.49
+ARG DOTNET_VERSION=8.0
+ARG LSB_RELEASE=22.04  # lsb_release -rs 
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Use bash for all RUN steps
+SHELL ["/bin/bash", "-c"]
+
+# Detect ARCH from TARGETPLATFORM and persist for reuse
+RUN case "$TARGETPLATFORM" in \
+      "linux/amd64") ARCH="amd64" ;; \
+      "linux/arm64") ARCH="arm64" ;; \
+      *) echo "Unsupported TARGETPLATFORM=$TARGETPLATFORM" && exit 1 ;; \
+    esac && \
+    echo "ARCH=$ARCH" > /arch.env
+
+# Install core packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    gnupg \
+    libssl-dev \
+    make \
+    openssh-client \
+    python3-dev \
+    python3-pip \
+    python3-venv \
+    shellcheck \
+    shfmt \
+    sudo \
+    unzip \
+    wget \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && apt-get install -y yarn
+
+# Install nvm
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh | bash
+
+# Set env
+ENV NVM_DIR=/root/.nvm
+
+# Install node
+RUN bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION"
+
+# set ENTRYPOINT for reloading nvm-environment
+ENTRYPOINT ["bash", "-c", "source $NVM_DIR/nvm.sh && exec \"$@\"", "--"]
+
+# Install PNPM
+RUN curl -fsSL https://get.pnpm.io/install.sh | \
+    env PNPM_HOME=/usr/local/bin SHELL=/bin/bash sh -
+
+# Install .NET SDK 8.0
+RUN curl -fsSL https://packages.microsoft.com/config/ubuntu/${LSB_RELEASE}/packages-microsoft-prod.deb -o packages-microsoft-prod.deb && \
+    dpkg -i packages-microsoft-prod.deb && \
+    apt-get update && \
+    apt-get install -y dotnet-sdk-${DOTNET_VERSION} && \
+    rm packages-microsoft-prod.deb
+
+# Install Google Cloud SDK
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    apt-get update && \
+    apt-get install -y google-cloud-sdk
+
+# Install Pulumi CLI
+RUN curl -fsSL https://get.pulumi.com | sh -s -- --install-root "/usr/local/pulumi"
+ENV PATH="/usr/local/pulumi/bin:$PATH"
+
+# Install Go
+RUN source /arch.env && \
+    curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" -o go.tar.gz && \
+    rm -rf /usr/local/go && \
+    tar -C /usr/local -xzf go.tar.gz && \
+    rm go.tar.gz
+ENV GOPATH="/go"
+ENV PATH="/usr/local/go/bin:${GOPATH}/bin:${PATH}"
+
+# Install latest released opsh from GitHub
+RUN curl -fsSL -o /usr/local/bin/opsh https://github.com/alexanderguy/opsh/releases/latest/download/opsh && \
+    chmod a+rx /usr/local/bin/opsh
+
+# Install pulumictl
+RUN source /arch.env && \
+    curl -L -o pulumictl.tar.gz \
+      "https://github.com/pulumi/pulumictl/releases/download/v${PULUMICTL_VERSION}/pulumictl-v${PULUMICTL_VERSION}-linux-${ARCH}.tar.gz" && \
+    tar -xzf pulumictl.tar.gz && \
+    chmod +x pulumictl && mv pulumictl /usr/local/bin/ && rm pulumictl.tar.gz
+
+# Install Solana CLI from Anza release channel
+ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
+RUN source /arch.env && \
+  if [ "$ARCH" = "amd64" ]; then \
+    sh -c "$(curl -fsSL https://release.anza.xyz/stable/install)"; \
+    solana --version \
+    else \
+    echo "Skipping Anza install on $ARCH"; \
+  fi
+
+# Install svmkit
+RUN source /arch.env && \
+    curl -s https://api.github.com/repos/abklabs/svmkit/releases/latest | \
+    jq -r --arg arch "$ARCH" '.assets[] | select(.name | test("linux-\($arch)\\.tar\\.gz$")) | .browser_download_url' | \
+     xargs curl -fsSL | tar -xzf -  -C /usr/local/bin svmkit
+
+# Install prove that supports TAP 14
+RUN cpan install TAP::Harness < /dev/null
+
+# Install rust to /usr/local
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:${PATH}
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+  | sh -s -- -y --no-modify-path --profile minimal \
+ && rustup toolchain install "${RUST_VERSION}" --profile minimal \
+ && rustup default "${RUST_VERSION}" \
+ && rustc -V && cargo -V
+
+# Install  cargo deb support
+RUN --mount=type=cache,target=/cargo-cache \
+    set -eux; \
+    CARGO_HOME=/cargo-cache cargo install --locked --root /usr/local cargo-deb; \
+    strip /usr/local/bin/cargo-deb || true
+
+# Solana builds need this.
+RUN apt-get update && apt-get install -y \
+    clang \
+    libclang-dev \
+    libudev-dev \
+    libusb-1.0-0-dev \
+    llvm-dev \
+    pkg-config \
+    protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV LLVM_CONFIG_PATH=/usr/bin/llvm-config
+
+# Optional: verify tools
+RUN pulumictl version && pulumi version && go version && dotnet --version
+
+WORKDIR /workdir


### PR DESCRIPTION
Added Rust support. 
  A simple implementation grew the Docker image to ~20G.  Added some overlay caching support that reduces it by ~10G.
  
Add SVMkit
  Using this to fetch debs for testing pipeline to simulate build artifacts.  Not sure if this is general useful or now.  If it is, the implementation in the Dockerfile seems very unclean, but not sure how to set up the required svmkit.sources in a cleaner way.  Cannot copy the svmkit.sources file into place as this container needs to build on buildkite.